### PR TITLE
#19 認証リッスン機能の追加

### DIFF
--- a/src/Auth.tsx
+++ b/src/Auth.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, ReactElement } from 'react';
+import { useDispatch } from 'react-redux';
+import { loadSignedIn } from './reducks/users/selectors';
+import { listenAuthState } from './reducks/users/operation';
+import { useSelector } from './reducks/store';
+
+/**
+ * サインインであれば子要素を表示し、そうでなければ子要素は表示しない
+ * @param param0 children - 子要素
+ * @returns サインイン状況に応じたコンポーネント
+ */
+function Auth({ children }: { children: ReactElement }) {
+  const dispatch = useDispatch();
+
+  const selector = useSelector((state) => state);
+  const isSignedIn = loadSignedIn(selector);
+
+  useEffect(() => {
+    if (!isSignedIn) {
+      // 初回表示にログイン状態でないければ、firebase内でログイン状態を確認
+      dispatch(listenAuthState());
+    }
+  }, []);
+
+  // サインインしていないければ、Authの子要素は表示させない
+  if (!isSignedIn) {
+    return <div />;
+  }
+  // サインインしていれば、Authの子要素は表示させる
+  return children;
+}
+
+export default Auth;

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -3,7 +3,7 @@ import { Route, Switch } from 'react-router';
 import { SignUp } from './components/templates/SignUp';
 import { SignIn } from './components/templates/SignIn';
 import { Top } from './components/templates/Top';
-
+import Auth from './Auth';
 /**
  * メインボディのルーティングを実施、
  * URIに応じてコンポーネントを切り替えてる
@@ -12,9 +12,11 @@ import { Top } from './components/templates/Top';
 function Router() {
   return (
     <Switch>
-      <Route exact path="(/)?" component={Top} />
       <Route exact path="/signup" component={SignUp} />
       <Route exact path="/signin" component={SignIn} />
+      <Auth>
+        <Route exact path="(/)?" component={Top} />
+      </Auth>
     </Switch>
   );
 }

--- a/src/reducks/users/operation.ts
+++ b/src/reducks/users/operation.ts
@@ -147,7 +147,7 @@ export function listenAuthState() {
       }
       dispatch(
         signInAction({
-          customer_id: data.customer_id ? data.customer_id : '',
+          customer_id: data.customer_id,
           email: data.email,
           isSignedIn: true,
           payment_method_id: user.uid,

--- a/src/reducks/users/selectors.ts
+++ b/src/reducks/users/selectors.ts
@@ -13,3 +13,8 @@ export const loadUserName = createSelector(
   [userSelector],
   (state) => state.username
 );
+/** サインインフラグの取得 */
+export const loadSignedIn = createSelector(
+  [userSelector],
+  (state) => state.isSignedIn
+);


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #19 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- サインインのとき以外は、トップページでメール、ユーザ名を表示しない
- ローカルでサインイン状態でない時、firebaseでサインイン状況かどうかを問い合わせ、サインインならユーザ情報をデータベースより取得し、ストアに保存し、そうでなければ、サインイン画面に飛ばす

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
なし
# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- `http://localhost:3000`にアクセス
- サインインであれば、メールとユーザ名表示
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
なし