### PR TITLE
#21 サインアウト処理の実装

### DIFF
--- a/src/components/templates/Top/presenter.tsx
+++ b/src/components/templates/Top/presenter.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import { loadUserEmail, loadUserName } from '../../../reducks/users/selectors';
 import { useSelector } from '../../../reducks/store';
+import { PrimaryButton } from '../../uiParts/PrimaryButton';
+import { signOut } from '../../../reducks/users/operation';
 /**
  * Top画面のコンポーネント
  * @return トップ画面のコンポーネント
  */
 function Top() {
+  const dispatch = useDispatch();
   const selector = useSelector((state) => state);
   const email = loadUserEmail(selector);
   const userName = loadUserName(selector);
@@ -15,6 +19,7 @@ function Top() {
       <h2>Top</h2>
       <div>userName: {userName}</div>
       <div>email: {email}</div>
+      <PrimaryButton label="サインアウト" onClick={() => dispatch(signOut())} />
     </>
   );
 }

--- a/src/reducks/users/operation.ts
+++ b/src/reducks/users/operation.ts
@@ -2,13 +2,14 @@ import { Dispatch } from 'react';
 import { Action } from '@reduxjs/toolkit';
 import {
   createUserWithEmailAndPassword,
-  signInWithEmailAndPassword,
   onAuthStateChanged,
+  signInWithEmailAndPassword,
+  signOut as signOutInFirebase,
 } from 'firebase/auth';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { push } from 'connected-react-router';
 import { auth, db, firebaseTimestamp } from '../../firebase/index';
-import { signInAction } from './update';
+import { signInAction, signOutAction } from './update';
 import { User } from './types';
 
 /**
@@ -127,7 +128,25 @@ export function signIn(email: string, password: string) {
     }
   };
 }
-
+/**
+ * サインアウト処理を行い、サインイン画面に飛ばす
+ * @returns サインアウト処理をするコールバック関数
+ */
+export function signOut() {
+  return async (dispatch: Dispatch<Action>) => {
+    try {
+      await signOutInFirebase(auth);
+      // ストアのユーザ情報を初期値にする
+      dispatch(signOutAction());
+      dispatch(push('/signin'));
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(error.message);
+      }
+      throw new Error('Failed to logout.');
+    }
+  };
+}
 /**
  * firebase内でサインイン状態を確認し、サインイン状態であればユーザ情報をセット、
  * そうでなければ、サインイン画面に飛ばす処理

--- a/src/reducks/users/update.ts
+++ b/src/reducks/users/update.ts
@@ -15,11 +15,16 @@ const userSlice = createSlice({
       // ストアの値の更新
       return updatedData;
     },
+    signOutAction: () => {
+      // サインアウト時は初期値に戻す
+      const updatedData = { ...initialUserState };
+      return updatedData;
+    },
   },
 });
 
 // action creatorをエクスポート
-export const { signInAction } = userSlice.actions;
+export const { signInAction, signOutAction } = userSlice.actions;
 
 // reducerをエクスポート
 export const user = userSlice.reducer;


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #21

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- サインアウト処理を実装
- サインアウトが成功すると、ストアのユーザ情報は初期値にして、サインイン画面に飛ばす
- サインアウト失敗すると例外をスロー

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
なし
# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- `http://localhost:3000/signin`でサインインして`http://loalhost:3000/`のサインアウトボタンを押す
- サインアウトすると、`http://loalhost:3000`へアクセスしても、サインイン画面になる
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
トップページは仮実装です
