### PR TITLE
#24 パスワードリセット画面の実装

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route, Switch } from 'react-router';
+import { PasswordReset } from './components/templates/PasswordReset';
 import { SignUp } from './components/templates/SignUp';
 import { SignIn } from './components/templates/SignIn';
 import { Top } from './components/templates/Top';
@@ -14,6 +15,7 @@ function Router() {
     <Switch>
       <Route exact path="/signup" component={SignUp} />
       <Route exact path="/signin" component={SignIn} />
+      <Route exact path="/signin/reset" component={PasswordReset} />
       <Auth>
         <Route exact path="(/)?" component={Top} />
       </Auth>

--- a/src/components/templates/PasswordReset/index.ts
+++ b/src/components/templates/PasswordReset/index.ts
@@ -1,0 +1,1 @@
+export { default as PasswordReset } from './presenter';

--- a/src/components/templates/PasswordReset/presenter.tsx
+++ b/src/components/templates/PasswordReset/presenter.tsx
@@ -1,0 +1,53 @@
+import React, { useCallback, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { TextInput } from '../../uiParts/TextInput';
+import { PrimaryButton } from '../../uiParts/PrimaryButton';
+import { resetPassword } from '../../../reducks/users/operation';
+import { useStyles } from './style';
+
+/**
+ * パスワードリセット画面のコンポーネント、
+ * 登録されたアドレスにパスワードリセットURL記載のメールを送信
+ * @return パスワードリセットコンポーネント
+ */
+function PasswordReset() {
+  const classes = useStyles();
+  const dispatch = useDispatch();
+
+  // 登録アドレス
+  const [email, setEmail] = useState('');
+
+  /** 入力メールアドレスの更新 */
+  const inputEmail = useCallback(
+    (e) => {
+      setEmail(e.target.value);
+    },
+    [setEmail]
+  );
+
+  return (
+    <div className={classes.root}>
+      <h2 className={classes.title}>パスワードリセット</h2>
+      <TextInput
+        fullWidth
+        label="登録済みのメールアドレス"
+        multiline={false}
+        required
+        rows={1}
+        value={email}
+        type="email"
+        onChange={inputEmail}
+      />
+      <div className={classes.button}>
+        <PrimaryButton
+          label="リセットメールを送信"
+          onClick={() => {
+            dispatch(resetPassword(email));
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default PasswordReset;

--- a/src/components/templates/PasswordReset/style.ts
+++ b/src/components/templates/PasswordReset/style.ts
@@ -1,0 +1,22 @@
+import { makeStyles } from '@material-ui/styles';
+
+/** スタイル */
+export const useStyles = makeStyles({
+  root: {
+    margin: '0 auto',
+    maxWidth: '400px',
+    padding: '1rem',
+    height: 'auto',
+    width: 'calc(100% - 2rem)',
+    textAlign: 'center',
+  },
+  title: {
+    textAlign: 'center',
+    color: '#4dd0e1',
+    fontSize: '1.563rem',
+    margin: '0 auto 1rem auto',
+  },
+  button: {
+    marginTop: '5rem',
+  },
+});

--- a/src/components/templates/SignIn/presenter.tsx
+++ b/src/components/templates/SignIn/presenter.tsx
@@ -1,9 +1,11 @@
 import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
 import { TextInput } from '../../uiParts/TextInput';
 import { PrimaryButton } from '../../uiParts/PrimaryButton';
 import { signIn } from '../../../reducks/users/operation';
 import { useStyles } from './style';
+import { TextLink } from '../../uiParts/TextLink';
 
 /**
  * サインイン画面のコンポーネント
@@ -63,6 +65,18 @@ function SignUp() {
           }}
         />
       </div>
+      <TextLink
+        label="アカウントをお持ちでない方はこちら"
+        onClick={() => {
+          dispatch(push('./signup'));
+        }}
+      />
+      <TextLink
+        label="パスワードを忘れた方はこちら"
+        onClick={() => {
+          dispatch(push('./signin/reset'));
+        }}
+      />
     </div>
   );
 }

--- a/src/components/templates/SignUp/presenter.tsx
+++ b/src/components/templates/SignUp/presenter.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
 import { makeStyles } from '@material-ui/styles';
 import { TextInput } from '../../uiParts/TextInput';
 import { PrimaryButton } from '../../uiParts/PrimaryButton';
 import { signUp } from '../../../reducks/users/operation';
 import { validateForm } from './hook';
+import { TextLink } from '../../uiParts/TextLink';
 
 /** スタイル */
 const useStyles = makeStyles({
@@ -115,6 +117,12 @@ function SignUp() {
           if (validateForm(userName, email, password, confirmPassword)) {
             dispatch(signUp(userName, email, password));
           }
+        }}
+      />
+      <TextLink
+        label="アカウントをお持ちの方はこちら"
+        onClick={() => {
+          dispatch(push('./signin'));
         }}
       />
     </div>

--- a/src/components/uiParts/TextLink/index.ts
+++ b/src/components/uiParts/TextLink/index.ts
@@ -1,0 +1,1 @@
+export { default as TextLink } from './presenter';

--- a/src/components/uiParts/TextLink/presenter.test.tsx
+++ b/src/components/uiParts/TextLink/presenter.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TextLink } from '.';
+import { useStyles } from './style';
+
+// スタイルを指定するuseStyles関数はモック化
+jest.mock('./style');
+const mockUseStyles = useStyles as jest.Mock;
+
+describe('TextLinkコンポーネントはパイパーリンクを表示する', () => {
+  test('labelに指定した文字をリンク文字列として表示している', () => {
+    // モックの帰り値を指定
+    mockUseStyles.mockReturnValue({});
+
+    // レンダリング
+    render(<TextLink label="メールアドレス" onClick={() => {}} />);
+
+    expect(screen.getByText('メールアドレス')).toBeInTheDocument();
+  });
+
+  test('マウスでリンクを押したら、onClickに指定したコールバック関数が実行される', () => {
+    // モックの返り値を指定
+    mockUseStyles.mockReturnValue({});
+
+    // モック関数を定義
+    const onClickMock = jest.fn();
+
+    // コンポーネントレンダリング
+    render(<TextLink label="メールアドレス" onClick={onClickMock} />);
+
+    // リンクテキストをクリック
+    const linkText = screen.getByText('メールアドレス');
+    userEvent.click(linkText);
+
+    expect(onClickMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('タブ選択してエンターを押すと、onClickに指定したコールバック関数が実行される', () => {
+    // モックの返り値を指定
+    mockUseStyles.mockReturnValue({});
+
+    // モック関数を定義
+    const onClickMock = jest.fn();
+
+    // コンポーネントレンダリング
+    render(<TextLink label="メールアドレス" onClick={onClickMock} />);
+
+    // タブ選択し、エンターを押す
+    userEvent.tab();
+    userEvent.keyboard('{Enter}');
+
+    expect(onClickMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/uiParts/TextLink/presenter.tsx
+++ b/src/components/uiParts/TextLink/presenter.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useStyles } from './style';
+
+/** テキストリンクの引き数の方 */
+type TextLinkProps = {
+  /** リンクの表示名 */
+  label: string;
+  /** リンクを押下した時のコールバック(画面性に利用)) */
+  onClick: React.ReactEventHandler<HTMLDivElement>;
+};
+
+/**
+ * テキストリンクのコンポーネント、
+ * マウスクリックだけでなく、タブ選択もできる
+ * @param props - label: 表示ラベル, onClick: クリックされた時のコールバック
+ * @returns
+ */
+function TextLink(props: TextLinkProps) {
+  const classes = useStyles();
+  const { label, onClick } = props;
+
+  return (
+    <div
+      className={classes.root}
+      role="link"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyPress={onClick}
+    >
+      {label}
+    </div>
+  );
+}
+
+export default TextLink;

--- a/src/components/uiParts/TextLink/style.ts
+++ b/src/components/uiParts/TextLink/style.ts
@@ -1,0 +1,10 @@
+import { makeStyles } from '@material-ui/styles';
+
+/** スタイル */
+export const useStyles = makeStyles({
+  root: {
+    cursor: 'pointer',
+    fontSize: '0.8rem',
+    margin: '0.5rem',
+  },
+});

--- a/src/reducks/users/operation.ts
+++ b/src/reducks/users/operation.ts
@@ -3,6 +3,7 @@ import { Action } from '@reduxjs/toolkit';
 import {
   createUserWithEmailAndPassword,
   onAuthStateChanged,
+  sendPasswordResetEmail,
   signInWithEmailAndPassword,
   signOut as signOutInFirebase,
 } from 'firebase/auth';
@@ -176,5 +177,23 @@ export function listenAuthState() {
         })
       );
     });
+  };
+}
+/**
+ * パスワードリセットメールを送信する処理のコールバック関数を返却
+ * @param email パスワードリセットメールを送信するアドレス
+ * @returns パスワードリセットメール処理をするコールバック関数
+ */
+export function resetPassword(email: string) {
+  return async (dispatch: Dispatch<Action>) => {
+    try {
+      await sendPasswordResetEmail(auth, email);
+      alert(
+        '指定アドレスにパスワードリセットメールを送信しました。ご確認ください。'
+      );
+      dispatch(push('./signin'));
+    } catch (error) {
+      alert('不具合が発生しました。時間を置いてもう一度実行してください。');
+    }
   };
 }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #24 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- パスワードリセット画面の追加
  - `http://localhost:3000/signin/reset`
- サインイン画面にパスワードお忘れの方はこちら、アカウントをお持ちでない方はこちらのリンクを記載
- サンアップ画面にアカウントをお持ちの方はこちらのリンクを記載

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
なし
# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- `http://localhost:3000/signin/reset`へアクセスすると、パスワードリセット画面になり、アドレスを入力すると、メールが飛びます。ただし、登録アカウントのアドレスのみ対応

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
なし