### PR TITLE
#51 編集は出品者だけが行えるようにした

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -31,7 +31,7 @@ function Router() {
             path="/favorite-products"
             component={FavoriteProductList}
           />
-          <Route path="/product/edit(/:id)?" component={ProductEdit} />
+          <Route path="/edit-product(/:id)?" component={ProductEdit} />
         </>
       </Auth>
     </Switch>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -9,6 +9,7 @@ import { ProductEdit } from './components/pages/ProductEdit';
 import { AllProductList } from './components/pages/AllProductList';
 import { ProductDetail } from './components/pages/ProductDetail';
 import { FavoriteProductList } from './components/pages/FavoriteProductList';
+import { ExhibitedProductList } from './components/pages/ExhibitedProductList';
 
 /**
  * メインボディのルーティングを実施、
@@ -32,6 +33,11 @@ function Router() {
             component={FavoriteProductList}
           />
           <Route path="/edit-product(/:id)?" component={ProductEdit} />
+          <Route
+            exact
+            path="/exhibited-products"
+            component={ExhibitedProductList}
+          />
         </>
       </Auth>
     </Switch>

--- a/src/assets/theme.ts
+++ b/src/assets/theme.ts
@@ -8,8 +8,8 @@ const theme = createTheme({
   palette: {
     primary: {
       light: '#88ffff',
-      main: '#4dd0e1',
-      dark: '#009faf',
+      main: '#53BF49',
+      dark: '#42993A',
       contrastText: '#000',
     },
     secondary: {

--- a/src/components/pages/ExhibitedProductList/index.ts
+++ b/src/components/pages/ExhibitedProductList/index.ts
@@ -1,0 +1,1 @@
+export { default as ExhibitedProductList } from './presenter';

--- a/src/components/pages/ExhibitedProductList/presenter.test.tsx
+++ b/src/components/pages/ExhibitedProductList/presenter.test.tsx
@@ -1,0 +1,89 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ExhibitedProductList } from '.';
+import { useSelector } from '../../../reducks/store';
+import { loadFavoriteProducts } from '../../../reducks/users/selectors';
+import { ProductFirebaseRepository } from '../../../repository/product';
+import { useStyles } from './style';
+
+// モジュールのモック化
+jest.mock('connected-react-router', () => jest.fn());
+jest.mock('react-redux');
+jest.mock('./style');
+jest.mock('../../../reducks/users/selectors');
+jest.mock('../../../reducks/store');
+jest.mock('../../../repository/product');
+jest.mock('../../../firebase', () => {});
+
+// const mockUseDispatch = useDispatch as jest.Mock;
+const mockUseStyles = useStyles as jest.Mock;
+const mockUseSelector = useSelector as jest.Mock;
+const mockLoadFavoriteProducts = loadFavoriteProducts as unknown as jest.Mock;
+const mockProductFirebaseRepository = ProductFirebaseRepository as jest.Mock;
+
+beforeEach(() => {
+  mockProductFirebaseRepository.mockClear();
+});
+
+describe('ExhibitedProductListコンポーネントは出品商品一覧を表示する', () => {
+  test('出品商品がない場合は「出品した商品がありません」と表示する', async () => {
+    // モックの帰り値を指定
+    mockUseStyles.mockReturnValue({});
+    mockUseSelector.mockReturnValue({});
+    mockLoadFavoriteProducts.mockReturnValue([]);
+    mockProductFirebaseRepository.mockImplementationOnce(() => ({
+      findByIds: () => ({
+        name: '',
+        description: '',
+        category: '',
+        gender: '',
+        price: 0,
+        id: '',
+        images: [
+          {
+            id: '',
+            path: '',
+          },
+        ],
+        updated_at: '',
+      }),
+    }));
+
+    await waitFor(() => {
+      render(<ExhibitedProductList />);
+    });
+    expect(screen.getByText('出品した商品がありません')).toBeInTheDocument();
+  });
+
+  test.skip('出品商品がある場合は商品リスト一覧を表示する', () => {});
+
+  test('ヘッダーテキストに「出品商品」と表示する', async () => {
+    // モックの帰り値を指定
+    mockUseStyles.mockReturnValue({});
+    mockUseSelector.mockReturnValue({});
+    mockLoadFavoriteProducts.mockReturnValue([]);
+    mockProductFirebaseRepository.mockImplementationOnce(() => ({
+      findByIds: () => ({
+        name: '',
+        description: '',
+        category: '',
+        gender: '',
+        price: 0,
+        id: '',
+        images: [
+          {
+            id: '',
+            path: '',
+          },
+        ],
+        updated_at: '',
+      }),
+    }));
+
+    await waitFor(() => {
+      render(<ExhibitedProductList />);
+    });
+    expect(screen.getByText('出品商品')).toBeInTheDocument();
+  });
+});

--- a/src/components/pages/ExhibitedProductList/presenter.tsx
+++ b/src/components/pages/ExhibitedProductList/presenter.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { ProductForDatabase } from '../../../reducks/products/types';
+import { useSelector } from '../../../reducks/store';
+import { loadExhibitedProducts } from '../../../reducks/users/selectors';
+import { ProductFirebaseRepository } from '../../../repository/product';
+import { Dialog } from '../../uniqueParts/Dialog';
+import { ProductList } from '../../uniqueParts/ProductList';
+import { useStyles } from './style';
+
+/**
+ * 出品商品リストを表示するコンポーネント
+ * @returns コンポーネント
+ */
+function ExhibitedProductList() {
+  const classes = useStyles();
+
+  // 出品商品idリストを情報取得
+  const selector = useSelector((state) => state);
+  const exhibitedProductIds = loadExhibitedProducts(selector);
+
+  const [openFailureDialog, setOpenFailureDialog] = useState(false);
+  const [exhibitedProducts, setExhibitedProducts] = useState<
+    ProductForDatabase[]
+  >([]);
+
+  // コンポーネントを表示したら、商品データを取得する
+  useEffect(() => {
+    // 非同期処理を中断するためのクラス
+    const abortCtrl = new AbortController();
+    try {
+      (async () => {
+        const repository = new ProductFirebaseRepository();
+        const products = await repository.findByIds(exhibitedProductIds);
+        setExhibitedProducts(products);
+      })();
+    } catch (error) {
+      setOpenFailureDialog(true);
+    }
+    return () => {
+      // 非同期処理を完了する前に、コンポーネントがアンマウントされたら非同期処理を中断する
+      abortCtrl.abort();
+    };
+  }, []);
+
+  // TODO
+  // 消した時にリアルタイムで更新するためにreduxで値を管理
+  return (
+    <section className={classes.root}>
+      <Dialog
+        isOpen={openFailureDialog}
+        setIsOpen={setOpenFailureDialog}
+        title="⚠エラー"
+        text="不具合が発生しました。通信状況を確認しリロードし直してください。"
+      />
+      <h1 className={classes.headerTitle}>出品商品</h1>
+      {exhibitedProducts.length ? (
+        <ProductList list={exhibitedProducts} />
+      ) : (
+        <p className={classes.noFavoriteText}>出品した商品がありません</p>
+      )}
+    </section>
+  );
+}
+
+export default ExhibitedProductList;

--- a/src/components/pages/ExhibitedProductList/style.ts
+++ b/src/components/pages/ExhibitedProductList/style.ts
@@ -1,0 +1,28 @@
+import { Theme } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
+
+/** スタイル */
+export const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    margin: '0 auto',
+    position: 'relative',
+    width: '100%',
+    textAlign: 'center',
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: '575px',
+    },
+    [theme.breakpoints.up('md')]: {
+      maxWidth: '1024px',
+    },
+  },
+  headerTitle: {
+    textAlign: 'center',
+    color: '#4dd0e1',
+    fontSize: '1.563rem',
+    margin: '1rem auto',
+  },
+  noFavoriteText: {
+    fontSize: '1.3rem',
+    margin: '5rem auto 1rem auto',
+  },
+}));

--- a/src/components/pages/FavoriteProductList/presenter.test.tsx
+++ b/src/components/pages/FavoriteProductList/presenter.test.tsx
@@ -27,7 +27,7 @@ beforeEach(() => {
 });
 
 describe('FavoriteProductListコンポーネントはお気に入り商品一覧を表示する', () => {
-  test('お気に入り商品がない場合は「お気に入りした商品がありません」と表示する', () => {
+  test('お気に入り商品がない場合は「お気に入りした商品がありません」と表示する', async () => {
     // モックの帰り値を指定
     mockUseStyles.mockReturnValue({});
     mockUseSelector.mockReturnValue({});
@@ -50,15 +50,15 @@ describe('FavoriteProductListコンポーネントはお気に入り商品一覧
       }),
     }));
 
-    waitFor(() => {
+    await waitFor(() => {
       render(<FavoriteProductList />);
-      expect(
-        screen.getByText('お気に入りした商品がありません')
-      ).toBeInTheDocument();
     });
+    expect(
+      screen.getByText('お気に入りした商品がありません')
+    ).toBeInTheDocument();
   });
   test.skip('お気に入り商品がある場合は商品リスト一覧を表示する', () => {});
-  test('ヘッダーテキストに「お気に入り商品」と表示する', () => {
+  test('ヘッダーテキストに「お気に入り商品」と表示する', async () => {
     // モックの帰り値を指定
     mockUseStyles.mockReturnValue({});
     mockUseSelector.mockReturnValue({});
@@ -81,9 +81,9 @@ describe('FavoriteProductListコンポーネントはお気に入り商品一覧
       }),
     }));
 
-    waitFor(() => {
+    await waitFor(() => {
       render(<FavoriteProductList />);
-      expect(screen.getByText('お気に入り商品')).toBeInTheDocument();
     });
+    expect(screen.getByText('お気に入り商品')).toBeInTheDocument();
   });
 });

--- a/src/components/pages/FavoriteProductList/presenter.tsx
+++ b/src/components/pages/FavoriteProductList/presenter.tsx
@@ -3,6 +3,7 @@ import { ProductForDatabase } from '../../../reducks/products/types';
 import { useSelector } from '../../../reducks/store';
 import { loadFavoriteProducts } from '../../../reducks/users/selectors';
 import { ProductFirebaseRepository } from '../../../repository/product';
+import { Dialog } from '../../uniqueParts/Dialog';
 import { ProductList } from '../../uniqueParts/ProductList';
 import { useStyles } from './style';
 
@@ -17,23 +18,41 @@ function FavoriteProductList() {
   const selector = useSelector((state) => state);
   const favoriteProductIds = loadFavoriteProducts(selector);
 
+  const [openFailureDialog, setOpenFailureDialog] = useState(false);
   const [favoriteProducts, setFavoriteProducts] = useState<
     ProductForDatabase[]
   >([]);
 
   // コンポーネントを表示したら、商品データを取得する
   useEffect(() => {
-    (async () => {
-      const repository = new ProductFirebaseRepository();
-      const products = await repository.findByIds(favoriteProductIds);
-      setFavoriteProducts(products);
-    })();
+    // 非同期処理を中断するためのクラス
+    const abortCtrl = new AbortController();
+
+    try {
+      (async () => {
+        const repository = new ProductFirebaseRepository();
+        const products = await repository.findByIds(favoriteProductIds);
+        setFavoriteProducts(products);
+      })();
+    } catch (error) {
+      setOpenFailureDialog(true);
+    }
+    return () => {
+      // 非同期処理を完了する前に、コンポーネントがアンマウントされたら非同期処理を中断する
+      abortCtrl.abort();
+    };
   }, []);
 
   return (
     <section className={classes.root}>
+      <Dialog
+        isOpen={openFailureDialog}
+        setIsOpen={setOpenFailureDialog}
+        title="⚠エラー"
+        text="不具合が発生しました。通信状況を確認しリロードし直してください。"
+      />
       <h1 className={classes.headerTitle}>お気に入り商品</h1>
-      {favoriteProductIds.length ? (
+      {favoriteProducts.length ? (
         <ProductList list={favoriteProducts} />
       ) : (
         <p className={classes.noFavoriteText}>お気に入りした商品がありません</p>

--- a/src/components/pages/ProductDetail/presenter.tsx
+++ b/src/components/pages/ProductDetail/presenter.tsx
@@ -1,5 +1,6 @@
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder';
+import { push } from 'connected-react-router';
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { ProductForDatabase } from '../../../reducks/products/types';
@@ -11,8 +12,9 @@ import {
 import { loadUserId } from '../../../reducks/users/selectors';
 import { ProductFirebaseRepository } from '../../../repository/product';
 import { UserFirebaseRepository } from '../../../repository/user';
-import { Dialog } from '../../uniqueParts/Dialog';
 import { IconButton } from '../../uiParts/IconButton';
+import { PrimaryButton } from '../../uiParts/PrimaryButton';
+import { Dialog } from '../../uniqueParts/Dialog';
 import { addBrTagToLineBreaks, recreateImages } from './hook';
 import { ImageSwiper } from './ImageSwiper';
 import { useStyles } from './style';
@@ -101,6 +103,15 @@ function ProductDetail() {
               onClick={handleFavoriteProduct}
               icon={favoriteIcon}
             />
+            <div className={classes.editButton}>
+              <PrimaryButton
+                label="商品の編集"
+                onClick={() => {
+                  dispatch(push(`/edit-product/${product.id}`));
+                }}
+                type="button"
+              />
+            </div>
             <h1>商品説明</h1>
             <p className={classes.productDescription}>
               {addBrTagToLineBreaks(product.description)}

--- a/src/components/pages/ProductDetail/presenter.tsx
+++ b/src/components/pages/ProductDetail/presenter.tsx
@@ -9,9 +9,11 @@ import {
   addFavoriteProduct,
   removeFavoriteProduct,
 } from '../../../reducks/users/operations';
-import { loadUserId } from '../../../reducks/users/selectors';
+import {
+  loadFavoriteProducts,
+  loadUserId,
+} from '../../../reducks/users/selectors';
 import { ProductFirebaseRepository } from '../../../repository/product';
-import { UserFirebaseRepository } from '../../../repository/user';
 import { IconButton } from '../../uiParts/IconButton';
 import { PrimaryButton } from '../../uiParts/PrimaryButton';
 import { Dialog } from '../../uniqueParts/Dialog';
@@ -52,7 +54,7 @@ function ProductDetail() {
     dispatch(addFavoriteProduct(productId));
     setIsFavorite((prevState) => !prevState);
   };
-
+  // お気に入りの場合は、無理潰されたハード、お気に入りではない場合枠組みのハード
   const favoriteIcon = isFavorite ? <FavoriteIcon /> : <FavoriteBorderIcon />;
   // 商品オーナーとログインユーザが同じ場合、編集ボタン表示
   const canEditProduct = userId === product?.owner;
@@ -66,16 +68,14 @@ function ProductDetail() {
         const productRepository = new ProductFirebaseRepository();
         const productData = await productRepository.fetch(productId);
         setProduct(productData);
-
-        // お気に入り商品なのかを判定している
-        const userRepository = new UserFirebaseRepository();
-        const user = await userRepository.fetchUser(userId);
-        const existFavorite = user.favorite_products.includes(productId);
-        setIsFavorite(existFavorite);
       } catch (error) {
         setOpenFailureDialog(true);
       }
     })();
+    // お気に入り商品なのかを判定している
+    const favoriteProductIds = loadFavoriteProducts(selector);
+    const existFavorite = favoriteProductIds.includes(productId);
+    setIsFavorite(existFavorite);
   }, []);
 
   return (

--- a/src/components/pages/ProductDetail/presenter.tsx
+++ b/src/components/pages/ProductDetail/presenter.tsx
@@ -33,7 +33,7 @@ function ProductDetail() {
   const productId = path.split('/product/')[1];
 
   const userId = loadUserId(selector);
-  const [product, setProduct] = useState<ProductForDatabase | null>(null);
+  const [product, setProduct] = useState<ProductForDatabase>();
   // ダイアログを管理するステート
   const [FailureDialog, setOpenFailureDialog] = useState(false);
   // お気に商品かどうかを保持するステート
@@ -54,6 +54,8 @@ function ProductDetail() {
   };
 
   const favoriteIcon = isFavorite ? <FavoriteIcon /> : <FavoriteBorderIcon />;
+  // 商品オーナーとログインユーザが同じ場合、編集ボタン表示
+  const canEditProduct = userId === product?.owner;
 
   // 商品詳細ページ訪問時に一度だけ実行
   useEffect(() => {
@@ -103,15 +105,17 @@ function ProductDetail() {
               onClick={handleFavoriteProduct}
               icon={favoriteIcon}
             />
-            <div className={classes.editButton}>
-              <PrimaryButton
-                label="商品の編集"
-                onClick={() => {
-                  dispatch(push(`/edit-product/${product.id}`));
-                }}
-                type="button"
-              />
-            </div>
+            {canEditProduct && (
+              <div className={classes.editButton}>
+                <PrimaryButton
+                  label="商品の編集"
+                  onClick={() => {
+                    dispatch(push(`/edit-product/${product.id}`));
+                  }}
+                  type="button"
+                />
+              </div>
+            )}
             <h1>商品説明</h1>
             <p className={classes.productDescription}>
               {addBrTagToLineBreaks(product.description)}

--- a/src/components/pages/ProductDetail/style.ts
+++ b/src/components/pages/ProductDetail/style.ts
@@ -72,4 +72,7 @@ export const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '1rem',
     marginLeft: '3rem',
   },
+  editButton: {
+    margin: '0 auto',
+  },
 }));

--- a/src/components/pages/ProductEdit/presenter.test.tsx
+++ b/src/components/pages/ProductEdit/presenter.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/react';
 import { ProductEdit } from '.';
 import { useStyles } from './style';
 import { useStyles as buttonUseStyle } from '../../uiParts/PrimaryButton/style';
+import { loadUserId } from '../../../reducks/users/selectors';
 
 // モジュールのモック化
 jest.mock('connected-react-router', () => jest.fn());
@@ -12,10 +13,12 @@ jest.mock('react-redux');
 jest.mock('./style');
 jest.mock('../../uiParts/PrimaryButton/style');
 jest.mock('../../../firebase', () => {});
+jest.mock('../../../reducks/users/selectors');
 
 const mockUseDispatch = useDispatch as jest.Mock;
 const mockUseStyles = useStyles as jest.Mock;
 const mockButtonStyle = buttonUseStyle as jest.Mock;
+const mockLoadUserId = loadUserId as unknown as jest.Mock;
 
 describe('ProductEditコンポーネントは、商品情報を登録する画面', () => {
   test('性別を選ぶ選択を選ぶ欄がある', () => {
@@ -23,6 +26,7 @@ describe('ProductEditコンポーネントは、商品情報を登録する画�
     mockUseStyles.mockReturnValue({});
     mockUseDispatch.mockReturnValue({});
     mockButtonStyle.mockReturnValue({});
+    mockLoadUserId.mockReturnValue('1111');
 
     render(<ProductEdit />);
 

--- a/src/components/pages/ProductEdit/presenter.tsx
+++ b/src/components/pages/ProductEdit/presenter.tsx
@@ -7,6 +7,8 @@ import { TextInput } from '../../uiParts/TextInput';
 import { useStyles } from './style';
 import { ImageAddArea } from './ImageAddArea';
 import { ProductFirebaseRepository } from '../../../repository/product';
+import { useSelector } from '../../../reducks/store';
+import { loadUserId } from '../../../reducks/users/selectors';
 
 /**
  * 商品編集をする画面の古音ポーネンと
@@ -15,6 +17,8 @@ import { ProductFirebaseRepository } from '../../../repository/product';
 function ProductEdit() {
   const classes = useStyles();
   const dispatch = useDispatch();
+  const selector = useSelector((state) => state);
+  const userId = loadUserId(selector);
 
   // 商品情報に必要なステートの定義
   const [productName, setProductName] = useState('');
@@ -105,7 +109,8 @@ function ProductEdit() {
               category,
               gender,
               images,
-              productPrice
+              productPrice,
+              userId
             )
           );
         }}

--- a/src/components/pages/ProductEdit/presenter.tsx
+++ b/src/components/pages/ProductEdit/presenter.tsx
@@ -25,7 +25,7 @@ function ProductEdit() {
   const [images, setImages] = useState<{ id: string; path: string }[]>([]);
 
   // 商品変種ページの場合、URLより商品idを取得する
-  const productId = window.location.pathname.split('/product/edit/')[1];
+  const productId = window.location.pathname.split('/edit-product/')[1];
 
   // プルダウン選択に必要なデータ定義
   const categories = [

--- a/src/components/uiParts/PrimaryButton/style.ts
+++ b/src/components/uiParts/PrimaryButton/style.ts
@@ -12,7 +12,7 @@ export const useStyles = makeStyles((theme: Theme) =>
       fontSize: 16,
       height: 48,
       marginBottom: 16,
-      width: 256,
+      width: '100%',
       '&:hover': {
         backgroundColor: theme.palette.primary.dark,
       },

--- a/src/components/uniqueParts/Header/HeaderMenuAtSignIn/presenter.tsx
+++ b/src/components/uniqueParts/Header/HeaderMenuAtSignIn/presenter.tsx
@@ -53,7 +53,7 @@ function HeaderMenuAtSignIn() {
         setOpenMenu={setOpenAccountMenu}
       />
       <IconButton
-        onClick={() => dispatch(push('/product/edit'))}
+        onClick={() => dispatch(push('/edit-product'))}
         icon={<PhotoCameraIcon />}
         label="出品"
       />

--- a/src/components/uniqueParts/Header/HeaderMenuAtSignIn/presenter.tsx
+++ b/src/components/uniqueParts/Header/HeaderMenuAtSignIn/presenter.tsx
@@ -32,6 +32,12 @@ function HeaderMenuAtSignIn() {
     },
     {
       onClick: () => {
+        dispatch(push('/exhibited-products'));
+      },
+      label: '出品商品一覧',
+    },
+    {
+      onClick: () => {
         dispatch(push('/favorite-products'));
       },
       label: 'お気に入り一覧',

--- a/src/components/uniqueParts/ProductList/ProductCard/presenter.test.tsx
+++ b/src/components/uniqueParts/ProductList/ProductCard/presenter.test.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { ProductCard } from '.';
 import noImage from '../../../../assets/images/no_image.png';
+import { loadUserId } from '../../../../reducks/users/selectors';
 import { useStyles } from './style';
 
 // スタイルを指定するuseStyles関数はモック化
@@ -14,10 +15,12 @@ jest.mock('react-redux');
 jest.mock('connected-react-router', () => jest.fn());
 // firebaseの取得メソッドをモック(CIでのテストで必要)
 jest.mock('../../../../firebase', () => {});
+jest.mock('../../../../reducks/users/selectors');
 
 const mockUseStyles = useStyles as jest.Mock;
 const mockTimestamp = jest.fn() as unknown as Timestamp;
 const mockUseDispatch = useDispatch as jest.Mock;
+const mockLoadUserId = loadUserId as unknown as jest.Mock;
 
 describe('商品情報カードコンポーネントは商品情報を表示する', () => {
   describe('値段は、３桁金馬区切りで円マークを接頭語に表示する', () => {
@@ -40,6 +43,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           },
         ],
         updated_at: mockTimestamp,
+        owner: '111',
       };
       render(
         <ProductCard
@@ -51,6 +55,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           id={productMock.id}
           images={productMock.images}
           updated_at={productMock.updated_at}
+          owner={productMock.owner}
         />
       );
       expect(screen.getByText('¥20,000')).toBeInTheDocument();
@@ -75,6 +80,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           },
         ],
         updated_at: mockTimestamp,
+        owner: '111',
       };
       render(
         <ProductCard
@@ -86,16 +92,18 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           id={productMock.id}
           images={productMock.images}
           updated_at={productMock.updated_at}
+          owner={productMock.owner}
         />
       );
       expect(screen.getByText('ラーメン')).toBeInTheDocument();
     });
   });
-  describe('各商品カードにはメニューボタンが表示される', () => {
-    test('メニューの一つである編集するボタンが表示されている', () => {
+  describe('商品編集者とログインユーザが同じ場合各商品カードにはメニューボタンが表示される', () => {
+    test('商品編集者とログインユーザが同じ場合は、メニューの一つである編集するボタンが表示されている', () => {
       // モックの帰り値を指定
       mockUseStyles.mockReturnValue({});
       mockUseDispatch.mockReturnValue({});
+      mockLoadUserId.mockReturnValue('1111');
 
       const productMock = {
         name: 'ラーメン',
@@ -111,7 +119,9 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           },
         ],
         updated_at: mockTimestamp,
+        owner: '1111',
       };
+
       render(
         <ProductCard
           name={productMock.name}
@@ -122,6 +132,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           id={productMock.id}
           images={productMock.images}
           updated_at={productMock.updated_at}
+          owner={productMock.owner}
         />
       );
       userEvent.tab();
@@ -129,10 +140,11 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
 
       expect(screen.getByText('編集する')).toBeInTheDocument();
     });
-    test('メニューの一つである削除するボタンが表示されている', () => {
+    test('商品編集者とログインユーザが同じ場合は、メニューの一つである削除するボタンが表示されている', () => {
       // モックの帰り値を指定
       mockUseStyles.mockReturnValue({});
       mockUseDispatch.mockReturnValue({});
+      mockLoadUserId.mockReturnValue('1111');
 
       const productMock = {
         name: 'ラーメン',
@@ -148,6 +160,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           },
         ],
         updated_at: mockTimestamp,
+        owner: '1111',
       };
       render(
         <ProductCard
@@ -159,12 +172,53 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           id={productMock.id}
           images={productMock.images}
           updated_at={productMock.updated_at}
+          owner={productMock.owner}
         />
       );
       userEvent.tab();
       userEvent.keyboard('{Enter}');
 
       expect(screen.getByText('削除する')).toBeInTheDocument();
+    });
+    test('商品編集者とログインユーザが異なる場合は、メニューボタンが表示されない', () => {
+      // モックの帰り値を指定
+      mockUseStyles.mockReturnValue({});
+      mockUseDispatch.mockReturnValue({});
+      mockLoadUserId.mockReturnValue('2222');
+
+      const productMock = {
+        name: 'ラーメン',
+        description: '',
+        category: '',
+        gender: '',
+        price: 20000,
+        id: '',
+        images: [
+          {
+            id: '',
+            path: noImage,
+          },
+        ],
+        updated_at: mockTimestamp,
+        owner: '1111',
+      };
+      render(
+        <ProductCard
+          name={productMock.name}
+          description={productMock.description}
+          category={productMock.category}
+          gender={productMock.gender}
+          price={productMock.price}
+          id={productMock.id}
+          images={productMock.images}
+          updated_at={productMock.updated_at}
+          owner={productMock.owner}
+        />
+      );
+      userEvent.tab();
+      userEvent.keyboard('{Enter}');
+
+      expect(screen.queryByText('削除する')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/uniqueParts/ProductList/ProductCard/presenter.tsx
+++ b/src/components/uniqueParts/ProductList/ProductCard/presenter.tsx
@@ -84,7 +84,7 @@ function ProductCard(props: ProductForDatabase) {
         >
           <MenuItem
             onClick={() => {
-              dispatch(push(`/product/edit/${id}`));
+              dispatch(push(`/edit-product/${id}`));
               handleCloseMenu();
             }}
           >

--- a/src/components/uniqueParts/ProductList/presenter.tsx
+++ b/src/components/uniqueParts/ProductList/presenter.tsx
@@ -25,6 +25,7 @@ function ProductList(props: Products) {
           id={product.id}
           images={product.images}
           updated_at={product.updated_at}
+          owner={product.owner}
         />
       ))}
     </div>

--- a/src/reducks/products/operations.ts
+++ b/src/reducks/products/operations.ts
@@ -8,6 +8,10 @@ import { ProductFirebaseRepository } from '../../repository/product';
 import { deleteProductAction, fetchProductsAction } from './updates';
 import { ProductForDatabase } from './types';
 import { RootState } from '../store';
+import {
+  addExhibitedProduct,
+  removeExhibitedProduct,
+} from '../users/operations';
 
 /**
  * 商品登録登録し、成功したらホームに戻るコールバックの定義
@@ -29,7 +33,7 @@ export function saveProduct(
   price: string,
   owner: string
 ) {
-  return async (dispatch: Dispatch<Action>) => {
+  return async (dispatch: Dispatch<unknown>) => {
     const nowTimeStamp = firebaseTimestamp.now();
     // 編集する商品のproductidを代入
     let id = productId;
@@ -55,6 +59,10 @@ export function saveProduct(
     try {
       const productRepository = new ProductFirebaseRepository();
       await productRepository.save(savedData);
+
+      // 商品追加をユーザ管理
+      dispatch(addExhibitedProduct(id));
+
       // 保存が成功したらホームへ
       dispatch(push('/'));
     } catch (error) {
@@ -69,11 +77,14 @@ export function saveProduct(
  * @returns 商品削除するコールバック
  */
 export function deleteProduct(id: string) {
-  return async (dispatch: Dispatch<Action>, getState: () => RootState) => {
+  return async (dispatch: Dispatch<unknown>, getState: () => RootState) => {
     try {
       // データベースの商品を削除
       const productRepository = new ProductFirebaseRepository();
       await productRepository.delete(id);
+
+      // 商品削除をユーザ管理
+      dispatch(removeExhibitedProduct(id));
 
       // 削除した商品以外の商品リストを作成
       const prevProducts = getState().products.list;

--- a/src/reducks/products/operations.ts
+++ b/src/reducks/products/operations.ts
@@ -16,6 +16,7 @@ import { RootState } from '../store';
  * @param category 商品カテゴリー
  * @param gender 性別
  * @param price 値段
+ * @param owner 商品出品者のユーザid
  * @returns 商品登録するコールバック
  */
 export function saveProduct(
@@ -25,7 +26,8 @@ export function saveProduct(
   category: string,
   gender: string,
   images: { id: string; path: string }[],
-  price: string
+  price: string,
+  owner: string
 ) {
   return async (dispatch: Dispatch<Action>) => {
     const nowTimeStamp = firebaseTimestamp.now();
@@ -48,6 +50,7 @@ export function saveProduct(
       name,
       price: parseInt(price, 10),
       updated_at: nowTimeStamp,
+      owner,
     };
     try {
       const productRepository = new ProductFirebaseRepository();

--- a/src/reducks/products/types.ts
+++ b/src/reducks/products/types.ts
@@ -18,6 +18,8 @@ export type ProductForDatabase = {
   images: { id: string; path: string }[];
   /** 更新日 */
   updated_at: Timestamp;
+  /** プロダクト出品者のユーザid */
+  owner: string;
 };
 
 /** reduxで扱う商品情報一覧の型 */

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -13,6 +13,7 @@ export const initialUserState: User = {
   uid: '',
   username: '',
   favoriteProducts: [],
+  exhibitedProducts: [],
 };
 
 /** 商品情報の初期化 */

--- a/src/reducks/users/operations.ts
+++ b/src/reducks/users/operations.ts
@@ -14,9 +14,53 @@ import { RootState } from '../store';
 import {
   signInAction,
   signOutAction,
+  updateExhibitedProductAction,
   updateFavoriteProductAction,
 } from './update';
 
+/**
+ * 自身で出品商品を管理処理をするコールバック関数の作成
+ * @param productId 出品商品id
+ * @returns コールバック
+ */
+export function addExhibitedProduct(productId: string) {
+  return async (dispatch: Dispatch<Action>, getState: () => RootState) => {
+    const userId = getState().user.uid;
+    const repository = new UserFirebaseRepository();
+
+    try {
+      const updatedExhibitedProducts = await repository.addExhibitedProduct(
+        userId,
+        productId
+      );
+      dispatch(updateExhibitedProductAction(updatedExhibitedProducts));
+    } catch (error) {
+      throw new Error('お気に入り登録失敗');
+    }
+  };
+}
+
+/**
+ * 出品商品を自身の管理から削除するコールバック関数の作成
+ * @param productId 削除した商品id
+ * @returns コールバック
+ */
+export function removeExhibitedProduct(productId: string) {
+  return async (dispatch: Dispatch<Action>, getState: () => RootState) => {
+    const userId = getState().user.uid;
+    const repository = new UserFirebaseRepository();
+
+    try {
+      const updatedExhibitedProducts = await repository.removeExhibitedProduct(
+        userId,
+        productId
+      );
+      dispatch(updateExhibitedProductAction(updatedExhibitedProducts));
+    } catch (error) {
+      throw new Error('出品商品登録解除失敗');
+    }
+  };
+}
 /**
  * お気に入り登録処理をするコールバック関数の作成
  * @param productId 登録したい商品id

--- a/src/reducks/users/operations.ts
+++ b/src/reducks/users/operations.ts
@@ -87,6 +87,7 @@ export function signUp(username: string, email: string, password: string) {
           updated_at: timestamp,
           username,
           favorite_products: [],
+          exhibited_products: [],
         };
         // ユーザー情報をデータベースに登録
         const userRepository = new UserFirebaseRepository();
@@ -130,6 +131,7 @@ export function signIn(email: string, password: string) {
           uid: user.uid,
           username: userData.username,
           favoriteProducts: userData.favorite_products,
+          exhibitedProducts: userData.exhibited_products,
         })
       );
       // サインインしたらトップページへ遷移
@@ -189,6 +191,7 @@ export function listenAuthState() {
           uid: user.uid,
           username: data.username,
           favoriteProducts: data.favorite_products,
+          exhibitedProducts: data.exhibited_products,
         })
       );
     });

--- a/src/reducks/users/selectors.ts
+++ b/src/reducks/users/selectors.ts
@@ -27,3 +27,8 @@ export const loadFavoriteProducts = createSelector(
   [userSelector],
   (state) => state.favoriteProducts
 );
+/** 出品商品リストの取得 */
+export const loadExhibitedProducts = createSelector(
+  [userSelector],
+  (state) => state.exhibitedProducts
+);

--- a/src/reducks/users/types.ts
+++ b/src/reducks/users/types.ts
@@ -10,6 +10,7 @@ export type User = {
   uid: string;
   username: string;
   favoriteProducts: string[];
+  exhibitedProducts: string[];
 };
 
 /** データベースで保存するユーザ情報の型 */
@@ -24,4 +25,6 @@ export type UserForDatabase = {
   username: string;
   /** お気に入り商品id一覧 */
   favorite_products: string[];
+  /** 出品商品id一覧 */
+  exhibited_products: string[];
 };

--- a/src/reducks/users/update.ts
+++ b/src/reducks/users/update.ts
@@ -33,12 +33,29 @@ const userSlice = createSlice({
       const updatedData = { ...state, favoriteProducts: [...action.payload] };
       return updatedData;
     },
+    /**
+     * 出品商品リストスライス
+     * @param state 現在のUserステート
+     * @param action 更新する出品商品リスト
+     * @returns 更新後のUser
+     */
+    updateExhibitedProductAction: (
+      state: User,
+      action: PayloadAction<string[]>
+    ) => {
+      const updatedData = { ...state, exhibitedProducts: [...action.payload] };
+      return updatedData;
+    },
   },
 });
 
 // action creatorをエクスポート
-export const { signInAction, signOutAction, updateFavoriteProductAction } =
-  userSlice.actions;
+export const {
+  signInAction,
+  signOutAction,
+  updateFavoriteProductAction,
+  updateExhibitedProductAction,
+} = userSlice.actions;
 
 // reducerをエクスポート
 export const user = userSlice.reducer;

--- a/src/repository/user/firestore.ts
+++ b/src/repository/user/firestore.ts
@@ -5,8 +5,8 @@ import {
   getDoc,
   setDoc,
 } from 'firebase/firestore';
-import type { UserForDatabase } from '../../reducks/users/types';
 import { db } from '../../firebase';
+import type { UserForDatabase } from '../../reducks/users/types';
 import { IUserRepository } from './interface';
 
 /**
@@ -17,6 +17,53 @@ class UserFirebaseRepository implements IUserRepository {
 
   constructor() {
     this.collection = 'users';
+  }
+
+  /**
+   * 指定ユーザに対して出品商品を追加
+   * @param userId ユーザ
+   * @param product 出品登録した商品id
+   * @returns 更新された出品商品リスト
+   */
+  async addExhibitedProduct(userId: string, product: string) {
+    try {
+      await setDoc(
+        doc(db, this.collection, userId),
+        { exhibited_products: arrayUnion(product) },
+        { merge: true }
+      );
+      // 更新された商品リストを取得し、返却
+      const user = await this.fetchUser(userId);
+      return user.exhibited_products;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(error.message);
+      }
+      throw new Error('ユーザーに対して出品商品の追加失敗');
+    }
+  }
+
+  /**
+   * 指定ユーザに対して出品商品を削除
+   * @param userId ユーザid
+   * @param product 出品削除した商品id
+   * @returns 更新された出品商品リスト
+   */
+  async removeExhibitedProduct(userId: string, product: string) {
+    try {
+      await setDoc(
+        doc(db, this.collection, userId),
+        { exhibited_products: arrayRemove(product) },
+        { merge: true }
+      );
+      const user = await this.fetchUser(userId);
+      return user.exhibited_products;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(error.message);
+      }
+      throw new Error('ユーザに対して出品商品登録解除失敗');
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #51 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
* ログインユーザと出品者がおなじ場合のみ編集ができるようにした
  * 商品一覧のカード右下のメニュー
* 商品詳細ページに変種ボタンを追加した（出品者とログインユーザが同じ場合のみ表示）
* 出品商品一覧を表示に対応
  * ロジックはお気に入り登録の時と同じ
  * 各ユーザのDBとストアに各出品商品のidの配列を保持させることで実現
# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- 出品した時の出品一覧は出品順にならない問題
- 出品商品一覧で商品を削除した際、すぐに反映されない
  - 更新時間を持たせてソートできたら解決だが、DBの操作がうまくできない
  - ストアで出品商品一覧管理することで解決、ストアが更新された時にレンダリングされるため