### PR TITLE
#54 商品購入機能を作る(見た目のみ)

### DIFF
--- a/src/components/uiParts/PrimaryButton/presenter.tsx
+++ b/src/components/uiParts/PrimaryButton/presenter.tsx
@@ -4,6 +4,8 @@ import { useStyles } from './style';
 
 /** ボタンコンポーネントの型定義 */
 type PrimaryButtonProps = {
+  /** 有効フラグ */
+  disabled?: boolean;
   /** ボタンに表記するラベル */
   label: string;
   /** ボタンタイプ(buttn | submit | reset) */
@@ -18,7 +20,7 @@ type PrimaryButtonProps = {
  * @return コンポーネント
  */
 function PrimaryButton(props: PrimaryButtonProps) {
-  const { label, onClick, type } = props;
+  const { label, onClick, type, disabled } = props;
   const classes = useStyles();
 
   return (
@@ -27,6 +29,7 @@ function PrimaryButton(props: PrimaryButtonProps) {
       variant="contained"
       onClick={onClick}
       type={type}
+      disabled={disabled}
     >
       {label}
     </Button>
@@ -36,6 +39,7 @@ function PrimaryButton(props: PrimaryButtonProps) {
 /** 引数のデフォルト値の設定 */
 PrimaryButton.defaultProps = {
   onClick: () => {},
+  disabled: false,
 };
 
 export default PrimaryButton;

--- a/src/components/uniqueParts/ProductList/ProductCard/presenter.test.tsx
+++ b/src/components/uniqueParts/ProductList/ProductCard/presenter.test.tsx
@@ -44,6 +44,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
         ],
         updated_at: mockTimestamp,
         owner: '111',
+        purchaser: '22',
       };
       render(
         <ProductCard
@@ -56,6 +57,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           images={productMock.images}
           updated_at={productMock.updated_at}
           owner={productMock.owner}
+          purchaser={productMock.purchaser}
         />
       );
       expect(screen.getByText('¥20,000')).toBeInTheDocument();
@@ -81,6 +83,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
         ],
         updated_at: mockTimestamp,
         owner: '111',
+        purchaser: '222',
       };
       render(
         <ProductCard
@@ -93,13 +96,14 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           images={productMock.images}
           updated_at={productMock.updated_at}
           owner={productMock.owner}
+          purchaser={productMock.purchaser}
         />
       );
       expect(screen.getByText('ラーメン')).toBeInTheDocument();
     });
   });
-  describe('商品編集者とログインユーザが同じ場合各商品カードにはメニューボタンが表示される', () => {
-    test('商品編集者とログインユーザが同じ場合は、メニューの一つである編集するボタンが表示されている', () => {
+  describe('購入者がいない、かつ、商品編集者とログインユーザが同じ場合各商品カードにはメニューボタンが表示される', () => {
+    test('purchaserが空文字、かつ、商品編集者とログインユーザが同じ場合は、メニューの一つである編集するボタンが表示されている', () => {
       // モックの帰り値を指定
       mockUseStyles.mockReturnValue({});
       mockUseDispatch.mockReturnValue({});
@@ -120,6 +124,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
         ],
         updated_at: mockTimestamp,
         owner: '1111',
+        purchaser: '',
       };
 
       render(
@@ -133,6 +138,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           images={productMock.images}
           updated_at={productMock.updated_at}
           owner={productMock.owner}
+          purchaser={productMock.purchaser}
         />
       );
       userEvent.tab();
@@ -140,7 +146,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
 
       expect(screen.getByText('編集する')).toBeInTheDocument();
     });
-    test('商品編集者とログインユーザが同じ場合は、メニューの一つである削除するボタンが表示されている', () => {
+    test('purchaserが空文字、かつ、商品編集者とログインユーザが同じ場合は、メニューの一つである削除するボタンが表示されている', () => {
       // モックの帰り値を指定
       mockUseStyles.mockReturnValue({});
       mockUseDispatch.mockReturnValue({});
@@ -161,6 +167,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
         ],
         updated_at: mockTimestamp,
         owner: '1111',
+        purchaser: '',
       };
       render(
         <ProductCard
@@ -173,6 +180,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           images={productMock.images}
           updated_at={productMock.updated_at}
           owner={productMock.owner}
+          purchaser={productMock.purchaser}
         />
       );
       userEvent.tab();
@@ -180,7 +188,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
 
       expect(screen.getByText('削除する')).toBeInTheDocument();
     });
-    test('商品編集者とログインユーザが異なる場合は、メニューボタンが表示されない', () => {
+    test('purchaserが空文字、かつ、商品編集者とログインユーザが異なる場合は、メニューボタンが表示されない', () => {
       // モックの帰り値を指定
       mockUseStyles.mockReturnValue({});
       mockUseDispatch.mockReturnValue({});
@@ -201,6 +209,7 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
         ],
         updated_at: mockTimestamp,
         owner: '1111',
+        purchaser: '',
       };
       render(
         <ProductCard
@@ -213,12 +222,100 @@ describe('商品情報カードコンポーネントは商品情報を表示す�
           images={productMock.images}
           updated_at={productMock.updated_at}
           owner={productMock.owner}
+          purchaser={productMock.purchaser}
         />
       );
       userEvent.tab();
       userEvent.keyboard('{Enter}');
 
       expect(screen.queryByText('削除する')).not.toBeInTheDocument();
+    });
+  });
+  describe('購入者がいる場合メニューボタンは、出品者にも表示されない', () => {
+    test('purchaserに値がある、かつ、商品編集者とログインユーザが同じ場合は、メニューの一つである編集するボタンは表示されない。', () => {
+      // モックの帰り値を指定
+      mockUseStyles.mockReturnValue({});
+      mockUseDispatch.mockReturnValue({});
+      mockLoadUserId.mockReturnValue('1111');
+
+      const productMock = {
+        name: 'ラーメン',
+        description: '',
+        category: '',
+        gender: '',
+        price: 20000,
+        id: '',
+        images: [
+          {
+            id: '',
+            path: noImage,
+          },
+        ],
+        updated_at: mockTimestamp,
+        owner: '1111',
+        purchaser: '1111', // 購入者がいる
+      };
+
+      render(
+        <ProductCard
+          name={productMock.name}
+          description={productMock.description}
+          category={productMock.category}
+          gender={productMock.gender}
+          price={productMock.price}
+          id={productMock.id}
+          images={productMock.images}
+          updated_at={productMock.updated_at}
+          owner={productMock.owner}
+          purchaser={productMock.purchaser}
+        />
+      );
+      userEvent.tab();
+      userEvent.keyboard('{Enter}');
+
+      expect(screen.queryByText('編集する')).not.toBeInTheDocument();
+    });
+    test('purchaserに値がある、かつ、商品編集者とログインユーザが異なる場合は、メニューボタンの一つである編集するボタンは表示されない', () => {
+      // モックの帰り値を指定
+      mockUseStyles.mockReturnValue({});
+      mockUseDispatch.mockReturnValue({});
+      mockLoadUserId.mockReturnValue('2222');
+
+      const productMock = {
+        name: 'ラーメン',
+        description: '',
+        category: '',
+        gender: '',
+        price: 20000,
+        id: '',
+        images: [
+          {
+            id: '',
+            path: noImage,
+          },
+        ],
+        updated_at: mockTimestamp,
+        owner: '1111',
+        purchaser: '88', // 購入者がいる
+      };
+      render(
+        <ProductCard
+          name={productMock.name}
+          description={productMock.description}
+          category={productMock.category}
+          gender={productMock.gender}
+          price={productMock.price}
+          id={productMock.id}
+          images={productMock.images}
+          updated_at={productMock.updated_at}
+          owner={productMock.owner}
+          purchaser={productMock.purchaser}
+        />
+      );
+      userEvent.tab();
+      userEvent.keyboard('{Enter}');
+
+      expect(screen.queryByText('購入する')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/uniqueParts/ProductList/ProductCard/presenter.tsx
+++ b/src/components/uniqueParts/ProductList/ProductCard/presenter.tsx
@@ -24,7 +24,7 @@ function ProductCard(props: ProductForDatabase) {
   const classes = useStyles();
   const selector = useSelector((state) => state);
   const dispatch = useDispatch();
-  const { images, name, price, id, owner } = props;
+  const { images, name, price, id, owner, purchaser } = props;
   const userId = loadUserId(selector);
 
   // メニュー表示フラグ
@@ -51,8 +51,10 @@ function ProductCard(props: ProductForDatabase) {
   const reshapePrime = price.toLocaleString();
   // 画像登録があれば、最初の画像をサムネイルにする
   const thumbnail = getThumbnail(images);
-  // 商品オーナーとログインユーザが同じなら編集ボタンを表示
-  const canEditProduct = owner === userId;
+
+  const isSold = purchaser !== '';
+  // 商品オーナーとログインユーザが同じ、かつ売り切れでないなら編集ボタンを表示
+  const canEditProduct = owner === userId && !isSold;
 
   return (
     <Card className={classes.root}>
@@ -62,11 +64,24 @@ function ProductCard(props: ProductForDatabase) {
         title="⚠エラー"
         text="情報取得に失敗しました。リロードしなおしてください。"
       />
-      <CardMedia
-        image={thumbnail}
-        className={classes.media}
-        onClick={() => dispatch(push(`/product/${id}`))}
-      />
+      {isSold ? (
+        <div className={classes.imageBox}>
+          <div className={classes.solidOut}>
+            <div className={classes.solidOutText}>sold</div>
+          </div>
+          <CardMedia
+            image={thumbnail}
+            className={classes.media}
+            onClick={() => dispatch(push(`/product/${id}`))}
+          />
+        </div>
+      ) : (
+        <CardMedia
+          image={thumbnail}
+          className={classes.media}
+          onClick={() => dispatch(push(`/product/${id}`))}
+        />
+      )}
       <CardContent className={classes.content}>
         <div>
           <Typography component="p" className={classes.productName}>

--- a/src/components/uniqueParts/ProductList/ProductCard/style.ts
+++ b/src/components/uniqueParts/ProductList/ProductCard/style.ts
@@ -28,6 +28,27 @@ export const useStyles = makeStyles((theme: Theme) => ({
     marginRight: 0,
     marginLeft: 'auto',
   },
+  imageBox: {
+    position: 'relative',
+  },
+  solidOut: {
+    position: 'absolute',
+    borderTop: '40px solid #ff0000',
+    borderRight: '40px solid transparent',
+    borderBottom: '40px solid transparent',
+    borderLeft: '40px solid #ff0000',
+  },
+  solidOutText: {
+    left: '-33px',
+    top: '-25px',
+    position: 'absolute',
+    color: '#ffffffff',
+    transform: 'rotate(-45deg)',
+    WebkitTransform: 'rotate(-45deg)',
+    backgroundColor: 'transparent',
+    fontSize: '1.3rem',
+    fontWeight: 'bold',
+  },
   media: {
     cursor: 'pointer',
     height: 0,

--- a/src/components/uniqueParts/ProductList/presenter.tsx
+++ b/src/components/uniqueParts/ProductList/presenter.tsx
@@ -26,6 +26,7 @@ function ProductList(props: Products) {
           images={product.images}
           updated_at={product.updated_at}
           owner={product.owner}
+          purchaser={product.purchaser}
         />
       ))}
     </div>

--- a/src/reducks/products/operations.ts
+++ b/src/reducks/products/operations.ts
@@ -10,9 +10,36 @@ import { ProductForDatabase } from './types';
 import { RootState } from '../store';
 import {
   addExhibitedProduct,
+  purchaseProduct,
   removeExhibitedProduct,
 } from '../users/operations';
 
+/**
+ * 購入された商品を登録処理するコールバック
+ * @param purchaserId 購入者ID
+ * @param purchaserdProductId 購入された商品ID
+ * @returns コールバック
+ */
+export function purchasedProduct(
+  purchaserId: string,
+  purchaserdProductId: string
+) {
+  return async (dispatch: Dispatch<unknown>) => {
+    const productRepository = new ProductFirebaseRepository();
+    try {
+      const allProducts = await productRepository.purchasedProduct(
+        purchaserId,
+        purchaserdProductId
+      );
+      // ユーザに対しても更新
+      dispatch(purchaseProduct(purchaserId, purchaserdProductId));
+      // ストアを更新
+      dispatch(fetchProductsAction(allProducts));
+    } catch (error) {
+      throw new Error('商品に対して購入された商品の登録処理失敗');
+    }
+  };
+}
 /**
  * 商品登録登録し、成功したらホームに戻るコールバックの定義
  * @param name 商品名
@@ -44,7 +71,7 @@ export function saveProduct(
       // 保存されるデータのキーであるidをデータとして保存したいため先に取得
       id = doc(firebaseCollection(db, 'products')).id;
     }
-
+    const purchaser = '';
     const savedData = {
       category,
       description,
@@ -55,6 +82,7 @@ export function saveProduct(
       price: parseInt(price, 10),
       updated_at: nowTimeStamp,
       owner,
+      purchaser,
     };
     try {
       const productRepository = new ProductFirebaseRepository();

--- a/src/reducks/products/types.ts
+++ b/src/reducks/products/types.ts
@@ -20,6 +20,8 @@ export type ProductForDatabase = {
   updated_at: Timestamp;
   /** プロダクト出品者のユーザid */
   owner: string;
+  /** 購入者のid */
+  purchaser: string;
 };
 
 /** reduxで扱う商品情報一覧の型 */

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -14,6 +14,7 @@ export const initialUserState: User = {
   username: '',
   favoriteProducts: [],
   exhibitedProducts: [],
+  purchasedProducts: [],
 };
 
 /** 商品情報の初期化 */

--- a/src/reducks/users/operations.ts
+++ b/src/reducks/users/operations.ts
@@ -16,7 +16,34 @@ import {
   signOutAction,
   updateExhibitedProductAction,
   updateFavoriteProductAction,
+  updatePurchasedProductAction,
 } from './update';
+
+/**
+ * 商品購入登録処理をするコールバック
+ * @param purchaser 購入者ID
+ * @param productId 購入した商品ID
+ * @returns コールバック
+ */
+export function purchaseProduct(
+  purchaser: string,
+  productId: string // sProductForDatabase
+) {
+  return async (dispatch: Dispatch<Action>) => {
+    const repository = new UserFirebaseRepository();
+
+    try {
+      const purchasedProducts = await repository.purchaseProduct(
+        purchaser,
+        productId
+      );
+
+      dispatch(updatePurchasedProductAction(purchasedProducts));
+    } catch (error) {
+      throw new Error('商品購入失敗');
+    }
+  };
+}
 
 /**
  * 自身で出品商品を管理処理をするコールバック関数の作成
@@ -132,6 +159,7 @@ export function signUp(username: string, email: string, password: string) {
           username,
           favorite_products: [],
           exhibited_products: [],
+          purchasedProducts: [],
         };
         // ユーザー情報をデータベースに登録
         const userRepository = new UserFirebaseRepository();
@@ -176,6 +204,7 @@ export function signIn(email: string, password: string) {
           username: userData.username,
           favoriteProducts: userData.favorite_products,
           exhibitedProducts: userData.exhibited_products,
+          purchasedProducts: userData.purchasedProducts,
         })
       );
       // サインインしたらトップページへ遷移
@@ -236,6 +265,7 @@ export function listenAuthState() {
           username: data.username,
           favoriteProducts: data.favorite_products,
           exhibitedProducts: data.exhibited_products,
+          purchasedProducts: data.purchasedProducts,
         })
       );
     });

--- a/src/reducks/users/types.ts
+++ b/src/reducks/users/types.ts
@@ -11,6 +11,8 @@ export type User = {
   username: string;
   favoriteProducts: string[];
   exhibitedProducts: string[];
+  /** 購入した商品一覧 */
+  purchasedProducts: string[];
 };
 
 /** データベースで保存するユーザ情報の型 */
@@ -27,4 +29,6 @@ export type UserForDatabase = {
   favorite_products: string[];
   /** 出品商品id一覧 */
   exhibited_products: string[];
+  /** 購入した商品一覧 */
+  purchasedProducts: string[];
 };

--- a/src/reducks/users/update.ts
+++ b/src/reducks/users/update.ts
@@ -46,6 +46,19 @@ const userSlice = createSlice({
       const updatedData = { ...state, exhibitedProducts: [...action.payload] };
       return updatedData;
     },
+    /**
+     * 購入商品更新スライス
+     * @param state 現在のUser
+     * @param action 購入商品リスト
+     * @returns 更新後のUser
+     */
+    updatePurchasedProductAction: (
+      state: User,
+      action: PayloadAction<string[]>
+    ) => {
+      const updatedData = { ...state, purchasedProducts: [...action.payload] };
+      return updatedData;
+    },
   },
 });
 
@@ -55,6 +68,7 @@ export const {
   signOutAction,
   updateFavoriteProductAction,
   updateExhibitedProductAction,
+  updatePurchasedProductAction,
 } = userSlice.actions;
 
 // reducerをエクスポート

--- a/src/repository/product/firestore.ts
+++ b/src/repository/product/firestore.ts
@@ -116,6 +116,25 @@ class ProductFirebaseRepository implements IProductRepository {
       }
     }
   }
+
+  /**
+   * 購入された商品DBに購入者IDを登録
+   * @param purchaserId 購入者ID
+   * @param purchasedProductId 購入された商品ID
+   * @returns 更新されたすべてのデータ
+   */
+  async purchasedProduct(purchaserId: string, purchasedProductId: string) {
+    try {
+      await setDoc(
+        doc(db, this.collection, purchasedProductId),
+        { purchaser: purchaserId },
+        { merge: true }
+      );
+      return await this.fetchAll();
+    } catch (error) {
+      throw new Error('商品コレクションに対する購入者登録失敗');
+    }
+  }
 }
 
 export default ProductFirebaseRepository;

--- a/src/repository/user/firestore.ts
+++ b/src/repository/user/firestore.ts
@@ -20,6 +20,29 @@ class UserFirebaseRepository implements IUserRepository {
   }
 
   /**
+   * 商品購入リスト更新
+   * @param userId ユーザID
+   * @param productId 商品ID
+   * @returns 更新された購入商品リスト
+   */
+  async purchaseProduct(userId: string, productId: string) {
+    try {
+      await setDoc(
+        doc(db, this.collection, userId),
+        { purchasedProducts: arrayUnion(productId) },
+        { merge: true }
+      );
+      const user = await this.fetchUser(userId);
+      return user.purchasedProducts;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(error.message);
+      }
+      throw new Error('ユーザーコレクションに対して購入商品登録失敗');
+    }
+  }
+
+  /**
    * 指定ユーザに対して出品商品を追加
    * @param userId ユーザ
    * @param product 出品登録した商品id


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
closes #54 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 商品購入したら、購入された胸を伝えるUI作成
  - 購入されたら出品者であっても編集・削除などのメニューを非表示にする

商品一覧

![image](https://user-images.githubusercontent.com/51454617/163219704-a9aaca58-98c2-43e1-a87e-b219b5e444ec.png)

商品詳細ページ

![image](https://user-images.githubusercontent.com/51454617/163219957-03b4901d-e2f4-4234-a5f4-5b78e417af4e.png)

- 商品を購入ボタンを押すと購入ダイアログが出てくる
- 各商品DBは出品者のUseridを保持するフィールド追加(purchaser: string)
- 各ユーザDBは購入商品のidを保持する配列フィールドを追加(purchaseproducts: string[])
  - ストアでも保持する

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
なし

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
なし
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
購入された側に通知送る処理などはまた未実装

よくよくは、メッセージのやりとりを追加
